### PR TITLE
#52 FIX (relay): recover live stream automatically after a doorbell reboot in lan mode

### DIFF
--- a/custom_components/ezviz_hp7/api.py
+++ b/custom_components/ezviz_hp7/api.py
@@ -391,40 +391,6 @@ class Hp7Api:
             _LOGGER.debug("EZVIZ HP7: local IP resolve failed for %s: %s", serial, exc)
             return None
 
-    def debug_connectivity_snapshot(self, serial: str) -> str:
-        """Best-effort one-line summary of what the EZVIZ cloud currently
-        reports for this device's connectivity (status code + CONNECTION
-        block), for comparing against a LAN-side "device offline" rejection.
-
-        The EZVIZ app's "online" badge reflects this same cloud-side status,
-        which can lag or differ from LAN reality (composite MAIN-CAM serials
-        in particular: the app can report the whole unit online while the
-        camera module behind it refuses to stream). Never raises — this is
-        diagnostic only and must not affect the retry/circuit-breaker flow.
-        """
-        try:
-            self.ensure_client()
-            if not self._client:
-                return "client unavailable"
-            devices = self._client.get_device_infos(serial)
-            device = None
-            if isinstance(devices, dict):
-                if isinstance(devices.get(serial), dict):
-                    device = devices[serial]
-                elif isinstance(devices.get("CONNECTION"), dict):
-                    device = devices
-            if not isinstance(device, dict):
-                return f"no device entry returned for {serial!r}"
-            device_infos = device.get("deviceInfos") or {}
-            connection = device.get("CONNECTION") or {}
-            return (
-                f"cloud status={device_infos.get('status')!r} "
-                f"localIp={connection.get('localIp')!r} "
-                f"netIp={connection.get('netIp')!r}"
-            )
-        except Exception as exc:  # noqa: BLE001
-            return f"snapshot failed: {exc}"
-
     def _try_unlock(self, serial: str, lock_no: int) -> bool:
         """Attempt to unlock a specific lock.
 

--- a/custom_components/ezviz_hp7/api.py
+++ b/custom_components/ezviz_hp7/api.py
@@ -391,6 +391,40 @@ class Hp7Api:
             _LOGGER.debug("EZVIZ HP7: local IP resolve failed for %s: %s", serial, exc)
             return None
 
+    def debug_connectivity_snapshot(self, serial: str) -> str:
+        """Best-effort one-line summary of what the EZVIZ cloud currently
+        reports for this device's connectivity (status code + CONNECTION
+        block), for comparing against a LAN-side "device offline" rejection.
+
+        The EZVIZ app's "online" badge reflects this same cloud-side status,
+        which can lag or differ from LAN reality (composite MAIN-CAM serials
+        in particular: the app can report the whole unit online while the
+        camera module behind it refuses to stream). Never raises — this is
+        diagnostic only and must not affect the retry/circuit-breaker flow.
+        """
+        try:
+            self.ensure_client()
+            if not self._client:
+                return "client unavailable"
+            devices = self._client.get_device_infos(serial)
+            device = None
+            if isinstance(devices, dict):
+                if isinstance(devices.get(serial), dict):
+                    device = devices[serial]
+                elif isinstance(devices.get("CONNECTION"), dict):
+                    device = devices
+            if not isinstance(device, dict):
+                return f"no device entry returned for {serial!r}"
+            device_infos = device.get("deviceInfos") or {}
+            connection = device.get("CONNECTION") or {}
+            return (
+                f"cloud status={device_infos.get('status')!r} "
+                f"localIp={connection.get('localIp')!r} "
+                f"netIp={connection.get('netIp')!r}"
+            )
+        except Exception as exc:  # noqa: BLE001
+            return f"snapshot failed: {exc}"
+
     def _try_unlock(self, serial: str, lock_no: int) -> bool:
         """Attempt to unlock a specific lock.
 

--- a/custom_components/ezviz_hp7/live_camera.py
+++ b/custom_components/ezviz_hp7/live_camera.py
@@ -43,6 +43,7 @@ config could lock the EZVIZ account in under a minute.
 from __future__ import annotations
 
 import asyncio
+import errno
 import logging
 import queue
 import socket
@@ -105,7 +106,20 @@ class Cpd7LanSource:
             local_ip, related, key, channel=self._channel,
             stream_quality=self._stream_quality,
         )
-        client.start()
+        try:
+            client.start()
+        except Exception:
+            # Same level as the "prewarm failed" warning below so this shows
+            # up without needing debug logging enabled — ip/related let us
+            # tell "stale/wrong LAN target" apart from "device genuinely not
+            # answering there".
+            _LOGGER.warning(
+                "Hp7StreamRelay: LAN InviteStream rejected (serial=%s ip=%s "
+                "related=%s) — see the error below for the device's raw "
+                "response",
+                self._serial, local_ip, related,
+            )
+            raise
         self._client = client
         self._decoder = StreamDecoder(client.ecdh_priv)
         _LOGGER.info(
@@ -272,6 +286,42 @@ def _sniff_video_codec(payload: bytes) -> Optional[str]:
         if nal in (0x67, 0x68, 0x65):
             return "h264"
     return None
+
+
+def _is_offline_error(exc: BaseException) -> bool:
+    """True when ``exc`` looks like "the device didn't answer" rather than a
+    misconfiguration or an EZVIZ-account/cloud problem.
+
+    The circuit breaker's LOCKOUT_BACKOFF exists to protect the EZVIZ
+    account from a bad config hammering the cloud (see module docstring) —
+    that's a real ban risk. A doorbell that's mid-reboot is not: it comes
+    back on its own in ~60-120s, and every source in this codebase that
+    detects it says so explicitly (LAN InviteStream timeout/refusal, VTM
+    stream-info timeout, the local SDK's "offline or unreachable"). Treating
+    that the same as a bad config means paying a 10-minute penalty for a
+    problem that was already fixing itself.
+    """
+    if isinstance(
+        exc, (ConnectionRefusedError, TimeoutError, socket.timeout, ConnectionError)
+    ):
+        return True
+    # EHOSTUNREACH / ENETUNREACH: the LAN can't route to the doorbell's IP at
+    # all — no ARP reply, cable/wifi down. Neither maps to a ConnectionError
+    # subclass in Python (only ECONNREFUSED/ECONNRESET/EPIPE/ECONNABORTED
+    # do), so it needs its own check. Observed in practice ~1s after a
+    # doorbell power-off, before the LAN InviteStream starts answering with
+    # its own explicit "offline" rejection.
+    if getattr(exc, "errno", None) in (errno.EHOSTUNREACH, errno.ENETUNREACH):
+        return True
+    text = str(exc).lower()
+    return (
+        "offline or unreachable" in text
+        or "timed out waiting for vtm stream info" in text
+        or "no <session> in invitestream" in text
+        or "connection refused" in text
+        or "host is unreachable" in text
+        or "network is unreachable" in text
+    )
 
 
 def _free_local_port() -> int:
@@ -455,6 +505,11 @@ class Hp7StreamRelay:
         self._port: int = 0
         self._last_attempt: float = 0.0
         self._last_error: Optional[str] = None
+        # Whether the last prewarm() failure looked like "device offline"
+        # rather than a misconfiguration — see _is_offline_error(). Keeps
+        # the breaker's 10-minute lockout reserved for the risk it was
+        # actually built to guard against.
+        self._last_error_offline: bool = False
         self._consecutive_failures: int = 0
         self._connect_lock = asyncio.Lock()
         # Shared (pre-warmed) VTM session + broadcast bookkeeping.
@@ -1074,6 +1129,7 @@ class Hp7StreamRelay:
                 info = await loop.run_in_executor(None, vtm.start)
                 self._consecutive_failures = 0
                 self._last_error = None
+                self._last_error_offline = False
                 _LOGGER.info(
                     "Hp7StreamRelay: pre-warm source up (serial=%s src=%s ssn=%s)",
                     self._serial,
@@ -1083,10 +1139,27 @@ class Hp7StreamRelay:
             except Exception as exc:
                 self._consecutive_failures += 1
                 self._last_error = str(exc)
+                self._last_error_offline = _is_offline_error(exc)
                 _LOGGER.warning(
-                    "Hp7StreamRelay: prewarm failed (%d/%d): %s",
-                    self._consecutive_failures, LOCKOUT_THRESHOLD, exc,
+                    "Hp7StreamRelay: prewarm failed (%d/%d, offline=%s, "
+                    "source=%s): %s",
+                    self._consecutive_failures, LOCKOUT_THRESHOLD,
+                    self._last_error_offline, self._stream_source, exc,
                 )
+                # Cross-check against what the cloud itself reports for this
+                # device, so "the EZVIZ app shows it online but we can't
+                # stream" is visible in the log instead of requiring the
+                # user to alt-tab to the app. Throttled (1st failure, then
+                # every 5th) so a long outage doesn't turn into a pagelist
+                # call every 20-30s on top of the retries themselves.
+                if self._consecutive_failures == 1 or self._consecutive_failures % 5 == 0:
+                    snapshot = await loop.run_in_executor(
+                        None, self._api.debug_connectivity_snapshot, self._serial
+                    )
+                    _LOGGER.warning(
+                        "Hp7StreamRelay: cloud connectivity snapshot "
+                        "(serial=%s): %s", self._serial, snapshot,
+                    )
                 return
             self._shared_vtm = vtm
             self._active_lan = isinstance(
@@ -1340,6 +1413,12 @@ class Hp7StreamRelay:
             )
 
     def _required_cooldown(self) -> float:
+        if self._last_error_offline:
+            # A rebooting doorbell isn't the account-ban risk the lockout
+            # exists for (see module docstring) — keep retrying at the
+            # normal cadence instead of escalating, so a reboot (~60-120s)
+            # doesn't cost a 10-minute wait.
+            return MIN_RETRY_INTERVAL
         if self._consecutive_failures >= LOCKOUT_THRESHOLD:
             return LOCKOUT_BACKOFF
         return MIN_RETRY_INTERVAL

--- a/custom_components/ezviz_hp7/live_camera.py
+++ b/custom_components/ezviz_hp7/live_camera.py
@@ -119,6 +119,17 @@ class Cpd7LanSource:
                 "response",
                 self._serial, local_ip, related,
             )
+            # fetch_lan_aes_key() caches the control key for
+            # Hp7Api.LAN_AES_KEY_TTL (1h) and is never invalidated on
+            # failure — every retry in that window keeps re-encrypting
+            # INIT/INVITE with the same key. If the doorbell rotates its
+            # local control key on a reboot, the device can't decrypt our
+            # request and falls back to exactly this generic plaintext
+            # rejection (Result 3, no <Session>) — indistinguishable on the
+            # wire from any other InviteStream refusal. Drop the cached key
+            # so the next attempt asks CAS for a fresh one instead of
+            # silently reusing a stale one for up to the full TTL.
+            self._api.invalidate_lan_aes_key(self._serial)
             raise
         self._client = client
         self._decoder = StreamDecoder(client.ecdh_priv)
@@ -218,20 +229,6 @@ DEAD_SUB_TIMEOUT = 30.0
 MIN_RETRY_INTERVAL = 30.0
 LOCKOUT_THRESHOLD = 3
 LOCKOUT_BACKOFF = 600.0
-# Cooldown for the LAN InviteStream's explicit "no <Session>" rejection
-# (_is_lan_channel_busy_error), as opposed to a network-level "can't reach it
-# at all" failure. Observed in practice: it does NOT self-clear under our
-# normal ~30s retry cadence even once the doorbell is confirmed back online
-# (via the cloud VTM path) — only a full HA restart, which happens to pause
-# attempts for a while, reliably un-sticks it. The INVITE XML we send
-# advertises `Authentication Interval="180"` (cpd7/lan_client.py); the
-# working theory is the device holds a session slot for that long, and our
-# own frequent retries keep refreshing its "still active" timer instead of
-# letting it expire — i.e. we may be the ones preventing our own recovery.
-# Not confirmed against protocol docs (none exist for this reverse-engineered
-# protocol, see cpd7/__init__.py) — a heuristic from observed behaviour, set
-# comfortably past that 180s with margin.
-LAN_CHANNEL_BUSY_COOLDOWN = 210.0
 
 INPUT_ACCEPT_TIMEOUT = 20.0
 
@@ -336,19 +333,6 @@ def _is_offline_error(exc: BaseException) -> bool:
         or "host is unreachable" in text
         or "network is unreachable" in text
     )
-
-
-def _is_lan_channel_busy_error(exc: BaseException) -> bool:
-    """True for the LAN InviteStream's explicit "no <Session>" rejection.
-
-    Distinct from the broader _is_offline_error(): a plain network-level
-    failure (connection refused, host unreachable) really does mean "still
-    booting", where a quick 30s retry is right. This one is the device
-    actively answering "I won't open this channel" while otherwise fully
-    reachable and working (confirmed via the cloud VTM path in parallel) —
-    see LAN_CHANNEL_BUSY_COOLDOWN for why it gets its own, longer cooldown.
-    """
-    return "no <session> in invitestream" in str(exc).lower()
 
 
 def _free_local_port() -> int:
@@ -537,10 +521,6 @@ class Hp7StreamRelay:
         # the breaker's 10-minute lockout reserved for the risk it was
         # actually built to guard against.
         self._last_error_offline: bool = False
-        # Whether the last failure was the LAN "channel busy" rejection
-        # specifically — see _is_lan_channel_busy_error() /
-        # LAN_CHANNEL_BUSY_COOLDOWN.
-        self._last_error_lan_busy: bool = False
         self._consecutive_failures: int = 0
         self._connect_lock = asyncio.Lock()
         # Shared (pre-warmed) VTM session + broadcast bookkeeping.
@@ -1161,7 +1141,6 @@ class Hp7StreamRelay:
                 self._consecutive_failures = 0
                 self._last_error = None
                 self._last_error_offline = False
-                self._last_error_lan_busy = False
                 _LOGGER.info(
                     "Hp7StreamRelay: pre-warm source up (serial=%s src=%s ssn=%s)",
                     self._serial,
@@ -1172,28 +1151,12 @@ class Hp7StreamRelay:
                 self._consecutive_failures += 1
                 self._last_error = str(exc)
                 self._last_error_offline = _is_offline_error(exc)
-                self._last_error_lan_busy = _is_lan_channel_busy_error(exc)
                 _LOGGER.warning(
                     "Hp7StreamRelay: prewarm failed (%d/%d, offline=%s, "
-                    "lan_busy=%s, source=%s): %s",
+                    "source=%s): %s",
                     self._consecutive_failures, LOCKOUT_THRESHOLD,
-                    self._last_error_offline, self._last_error_lan_busy,
-                    self._stream_source, exc,
+                    self._last_error_offline, self._stream_source, exc,
                 )
-                # Cross-check against what the cloud itself reports for this
-                # device, so "the EZVIZ app shows it online but we can't
-                # stream" is visible in the log instead of requiring the
-                # user to alt-tab to the app. Throttled (1st failure, then
-                # every 5th) so a long outage doesn't turn into a pagelist
-                # call every 20-30s on top of the retries themselves.
-                if self._consecutive_failures == 1 or self._consecutive_failures % 5 == 0:
-                    snapshot = await loop.run_in_executor(
-                        None, self._api.debug_connectivity_snapshot, self._serial
-                    )
-                    _LOGGER.warning(
-                        "Hp7StreamRelay: cloud connectivity snapshot "
-                        "(serial=%s): %s", self._serial, snapshot,
-                    )
                 return
             self._shared_vtm = vtm
             self._active_lan = isinstance(
@@ -1447,13 +1410,6 @@ class Hp7StreamRelay:
             )
 
     def _required_cooldown(self) -> float:
-        if self._last_error_lan_busy:
-            # Checked before the general offline case: retrying too fast
-            # appears to be exactly what keeps the device's LAN channel
-            # stuck (see LAN_CHANNEL_BUSY_COOLDOWN) — a plain 30s cadence
-            # here would just perpetuate the problem it's meant to recover
-            # from.
-            return LAN_CHANNEL_BUSY_COOLDOWN
         if self._last_error_offline:
             # A rebooting doorbell isn't the account-ban risk the lockout
             # exists for (see module docstring) — keep retrying at the

--- a/custom_components/ezviz_hp7/live_camera.py
+++ b/custom_components/ezviz_hp7/live_camera.py
@@ -218,6 +218,20 @@ DEAD_SUB_TIMEOUT = 30.0
 MIN_RETRY_INTERVAL = 30.0
 LOCKOUT_THRESHOLD = 3
 LOCKOUT_BACKOFF = 600.0
+# Cooldown for the LAN InviteStream's explicit "no <Session>" rejection
+# (_is_lan_channel_busy_error), as opposed to a network-level "can't reach it
+# at all" failure. Observed in practice: it does NOT self-clear under our
+# normal ~30s retry cadence even once the doorbell is confirmed back online
+# (via the cloud VTM path) — only a full HA restart, which happens to pause
+# attempts for a while, reliably un-sticks it. The INVITE XML we send
+# advertises `Authentication Interval="180"` (cpd7/lan_client.py); the
+# working theory is the device holds a session slot for that long, and our
+# own frequent retries keep refreshing its "still active" timer instead of
+# letting it expire — i.e. we may be the ones preventing our own recovery.
+# Not confirmed against protocol docs (none exist for this reverse-engineered
+# protocol, see cpd7/__init__.py) — a heuristic from observed behaviour, set
+# comfortably past that 180s with margin.
+LAN_CHANNEL_BUSY_COOLDOWN = 210.0
 
 INPUT_ACCEPT_TIMEOUT = 20.0
 
@@ -322,6 +336,19 @@ def _is_offline_error(exc: BaseException) -> bool:
         or "host is unreachable" in text
         or "network is unreachable" in text
     )
+
+
+def _is_lan_channel_busy_error(exc: BaseException) -> bool:
+    """True for the LAN InviteStream's explicit "no <Session>" rejection.
+
+    Distinct from the broader _is_offline_error(): a plain network-level
+    failure (connection refused, host unreachable) really does mean "still
+    booting", where a quick 30s retry is right. This one is the device
+    actively answering "I won't open this channel" while otherwise fully
+    reachable and working (confirmed via the cloud VTM path in parallel) —
+    see LAN_CHANNEL_BUSY_COOLDOWN for why it gets its own, longer cooldown.
+    """
+    return "no <session> in invitestream" in str(exc).lower()
 
 
 def _free_local_port() -> int:
@@ -510,6 +537,10 @@ class Hp7StreamRelay:
         # the breaker's 10-minute lockout reserved for the risk it was
         # actually built to guard against.
         self._last_error_offline: bool = False
+        # Whether the last failure was the LAN "channel busy" rejection
+        # specifically — see _is_lan_channel_busy_error() /
+        # LAN_CHANNEL_BUSY_COOLDOWN.
+        self._last_error_lan_busy: bool = False
         self._consecutive_failures: int = 0
         self._connect_lock = asyncio.Lock()
         # Shared (pre-warmed) VTM session + broadcast bookkeeping.
@@ -1130,6 +1161,7 @@ class Hp7StreamRelay:
                 self._consecutive_failures = 0
                 self._last_error = None
                 self._last_error_offline = False
+                self._last_error_lan_busy = False
                 _LOGGER.info(
                     "Hp7StreamRelay: pre-warm source up (serial=%s src=%s ssn=%s)",
                     self._serial,
@@ -1140,11 +1172,13 @@ class Hp7StreamRelay:
                 self._consecutive_failures += 1
                 self._last_error = str(exc)
                 self._last_error_offline = _is_offline_error(exc)
+                self._last_error_lan_busy = _is_lan_channel_busy_error(exc)
                 _LOGGER.warning(
                     "Hp7StreamRelay: prewarm failed (%d/%d, offline=%s, "
-                    "source=%s): %s",
+                    "lan_busy=%s, source=%s): %s",
                     self._consecutive_failures, LOCKOUT_THRESHOLD,
-                    self._last_error_offline, self._stream_source, exc,
+                    self._last_error_offline, self._last_error_lan_busy,
+                    self._stream_source, exc,
                 )
                 # Cross-check against what the cloud itself reports for this
                 # device, so "the EZVIZ app shows it online but we can't
@@ -1413,6 +1447,13 @@ class Hp7StreamRelay:
             )
 
     def _required_cooldown(self) -> float:
+        if self._last_error_lan_busy:
+            # Checked before the general offline case: retrying too fast
+            # appears to be exactly what keeps the device's LAN channel
+            # stuck (see LAN_CHANNEL_BUSY_COOLDOWN) — a plain 30s cadence
+            # here would just perpetuate the problem it's meant to recover
+            # from.
+            return LAN_CHANNEL_BUSY_COOLDOWN
         if self._last_error_offline:
             # A rebooting doorbell isn't the account-ban risk the lockout
             # exists for (see module docstring) — keep retrying at the

--- a/custom_components/ezviz_hp7/live_camera.py
+++ b/custom_components/ezviz_hp7/live_camera.py
@@ -462,6 +462,10 @@ class Hp7StreamRelay:
         self._shared_vtm: Any = None
         self._shared_stop = threading.Event()
         self._shared_reader: Optional[threading.Thread] = None
+        # Event loop the shared session was opened from, so the broadcast
+        # reader thread can hop back onto it if it dies on its own (see
+        # _handle_reader_exit).
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
         # Per-subscriber queues populated by the shared reader.
         self._sub_v_qs: List["queue.Queue[Optional[bytes]]"] = []
         self._sub_a_qs: List["queue.Queue[Optional[bytes]]"] = []
@@ -1042,6 +1046,7 @@ class Hp7StreamRelay:
         idle teardown timer is just reset.
         """
         loop = asyncio.get_event_loop()
+        self._loop = loop
         async with self._shared_lock:
             if self._shared_vtm is not None:
                 self._arm_idle_timer()
@@ -1138,8 +1143,41 @@ class Hp7StreamRelay:
             self._shared_reader = None
         _LOGGER.debug("Hp7StreamRelay: shared VTM torn down (serial=%s)", self._serial)
 
+    async def _handle_reader_exit(self, my_vtm: Any) -> None:
+        """Reset shared-session state after the broadcast reader dies on
+        its own (network error, device offline, etc. — NOT a requested
+        teardown via _shutdown_shared).
+
+        Without this, self._shared_vtm stays non-None forever: prewarm()
+        keeps seeing "a shared session is already active" and every future
+        client just subscribes to queues nobody is feeding any more, then
+        sits through the full ffmpeg stall timeout before giving up — on
+        loop, until HA itself is restarted.
+        """
+        async with self._shared_lock:
+            if self._shared_vtm is not my_vtm:
+                # Already superseded by a clean shutdown/restart; nothing
+                # to do here.
+                return
+            self._shared_vtm = None
+            self._active_lan = False
+            if self._idle_handle is not None:
+                self._idle_handle.cancel()
+                self._idle_handle = None
+        loop = asyncio.get_event_loop()
+        try:
+            await loop.run_in_executor(None, my_vtm.close)
+        except Exception:  # noqa: BLE001
+            pass
+        self._shared_reader = None
+        _LOGGER.debug(
+            "Hp7StreamRelay: shared VTM reset after unexpected reader exit "
+            "(serial=%s)", self._serial,
+        )
+
     def _broadcast_reader(self) -> None:
         """Read VTM payloads -> PesParser -> fan out to per-client queues."""
+        my_vtm = self._shared_vtm
         parser = PesParser()
         # Fresh session — a cached GOP from the previous source is stale.
         with self._gop_lock:
@@ -1282,6 +1320,18 @@ class Hp7StreamRelay:
                 try:
                     q.put_nowait(None)
                 except queue.Full:
+                    pass
+            if not self._shared_stop.is_set() and self._loop is not None:
+                # Exited on its own (network error) rather than via
+                # _shutdown_shared, which would have already cleared
+                # self._shared_vtm itself. Hop onto the event loop to reset
+                # it there too, so the next prewarm() opens a fresh session
+                # instead of reusing a session nothing is feeding any more.
+                try:
+                    asyncio.run_coroutine_threadsafe(
+                        self._handle_reader_exit(my_vtm), self._loop
+                    )
+                except Exception:  # noqa: BLE001
                     pass
             _LOGGER.info(
                 "Hp7StreamRelay: broadcast done video=%d B audio=%d B "


### PR DESCRIPTION
## Summary
- Reset `_shared_vtm` when the broadcast reader thread dies on its own (network error), not just on an intentional teardown — previously every client got stuck forever on dead queues until Home Assistant was restarted.
- Split the circuit breaker's "device offline" case from real misconfiguration: a transient network failure now retries every 30s instead of escalating to the 10-minute `LOCKOUT_BACKOFF` meant to protect the EZVIZ account from a bad config.
- Invalidate the cached LAN control key (`invalidate_lan_aes_key`) whenever a `local`-source `InviteStream` attempt fails. The key was cached for `LAN_AES_KEY_TTL` (1h) and never dropped on failure, so a doorbell that rotates its key on reboot kept getting rejected (`Result 3`, no `<Session>`) for up to an hour even while confirmed reachable via the cloud path — recovery observed to drop from up to ~60 min down to ~2 min with this fix.

## Test plan
- Manually power-cycled an HP5 (source=`local`) multiple times, confirmed the live stream recovers on its own within a couple of minutes, without restarting HA
- Confirmed the breaker no longer escalates to a 10-minute lockout for plain "device offline" errors (`ConnectionRefusedError`, `EHOSTUNREACH`/`ENETUNREACH`, timeouts)
